### PR TITLE
fix: mbti 통계 조회 메서드 변경, 특정 질문 통계 없을 시 추가하는 메서드 추가

### DIFF
--- a/src/db/models/StatisticModel.js
+++ b/src/db/models/StatisticModel.js
@@ -42,8 +42,11 @@ class StatisticModel {
       { arrayFilters: [ { "elem.idx": { $in: [13, 14, 15, 16] } } ] }
     );
   }
+  async findMbtiStat(parent, mbtiType) {
+    return await Statistic.findOne({ parent, mbtiType }).lean();
+  }
   async findMBTI(parent, mbtiType, answerMbtiType) {
-    
+
     // 집계함수 aggregate를 사용하여 특정 answerMbtiType에 대한 데이터만 불러온다.
 
     return await Statistic.aggregate([
@@ -67,6 +70,15 @@ class StatisticModel {
   async create(statistic) {
     return (await Statistic.create(statistic)).toObject()
   }
+  
+  async createNew(statistic) {
+    const { mbtiType, parent, newElement } = statistic;
+    return await Statistic.updateOne(
+      { mbtiType, parent },
+      { $push: { mbtiData: newElement } }
+    );
+  }
+
   async update(statisticInfo) {
     const { parent, mbtiType, newSelection } = statisticInfo;
 

--- a/src/services/statisticService.js
+++ b/src/services/statisticService.js
@@ -8,6 +8,9 @@ class StatisticService {
   async imsiUpdate(mbti) {
     return await this.statisticModel.imsiUpdate(mbti);
   }
+  async getMbtiStatistic(parent, mbtiType) {
+    return await this.statisticModel.findMbtiStat(parent, mbtiType);
+  }
   async getStatistic(parent, mbtiType, answerMbtiType) {
     return await this.statisticModel.findMBTI(parent, mbtiType, answerMbtiType);
   }
@@ -21,6 +24,9 @@ class StatisticService {
   }
   async addStatistic(statistic) {
     return await this.statisticModel.create(statistic);
+  }
+  async addNewStatistic(statistic) {
+    return await this.statisticModel.createNew(statistic);
   }
   async updateStatistic(statisticInfo) {
     return await this.statisticModel.update(statisticInfo);


### PR DESCRIPTION
> 변경사항

- mbti 유형별로 통계 정보가 없는 질문/답변의 경우 새로 추가해주는 로직 작성
- 유형별 통계 정보에 새 질문/답변 추가해주는 db 메서드 로직 작성

> 변경사유

- 기존에는 맨 처음에 추가한 16개 문항에 대해서만 통계 정보를 저장했다.
- 하지만 문항이 랜덤으로 16개가 표시됨에 따라 통계 정보 저장 로직의 개념을 확장할 필요가 있었다.
- 따라서 기존 통계 정보에서 특정 질문에 대한 통계가 없을 시 새로 추가해주는 코드를 작성했다.
- 추후 문항이 계속 추가되어도 통계에 문제없이 반영 가능하다.